### PR TITLE
Cons

### DIFF
--- a/include/antidote_utils.hrl
+++ b/include/antidote_utils.hrl
@@ -19,5 +19,5 @@
                           txid :: txid()}).
 
 -type vectorclock() :: vectorclock:vectorclock().
--type txid() :: #tx_id{} | no_txn_inserting_from_log.
+-type txid() :: #tx_id{} | no_txn_inserting_from_log | .
 -type clocksi_payload() :: #clocksi_payload{}.

--- a/include/antidote_utils.hrl
+++ b/include/antidote_utils.hrl
@@ -19,5 +19,5 @@
                           txid :: txid()}).
 
 -type vectorclock() :: vectorclock:vectorclock().
--type txid() :: #tx_id{} | no_txn_inserting_from_log | .
+-type txid() :: #tx_id{} | no_txn_inserting_from_log.
 -type clocksi_payload() :: #clocksi_payload{}.

--- a/include/antidote_utils.hrl
+++ b/include/antidote_utils.hrl
@@ -19,5 +19,5 @@
                           txid :: txid()}).
 
 -type vectorclock() :: vectorclock:vectorclock().
--type txid() :: #tx_id{}.
+-type txid() :: #tx_id{} | no_txn_inserting_from_log.
 -type clocksi_payload() :: #clocksi_payload{}.

--- a/src/vector_orddict.erl
+++ b/src/vector_orddict.erl
@@ -118,8 +118,8 @@ insert_bigger_internal(Vector,Val,[],0) ->
 
 insert_bigger_internal(Vector,Val,[{FirstClock,FirstVal}|Rest],Size) ->
 	FirstClock=case FirstVal of
-		{_CommitVC, DepVC, _ReadTime}->
-			DepVC;
+		{CommitVC, _DepVC, _ReadTime}->
+			CommitVC;
 		CommitVC->
 			CommitVC
 	end,

--- a/src/vector_orddict.erl
+++ b/src/vector_orddict.erl
@@ -117,12 +117,18 @@ insert_bigger_internal(Vector,Val,[],0) ->
     {[{Vector,Val}],1};
 
 insert_bigger_internal(Vector,Val,[{FirstClock,FirstVal}|Rest],Size) ->
-    case not vectorclock:le(Vector,FirstClock) of
-	true ->
-	    {[{Vector,Val}|[{FirstClock,FirstVal}|Rest]],Size+1};
-	false ->
-	    {[{FirstClock,FirstVal}|Rest],Size}
-    end.
+	FirstClock=case FirstVal of
+		{_CommitVC, DepVC, _ReadTime}->
+			DepVC;
+		CommitVC->
+			CommitVC
+	end,
+	case not vectorclock:le(Vector, FirstClock) of
+		true->
+			{[{Vector, Val}|[{FirstClock, FirstVal}|Rest]], Size+1};
+		false->
+			{[{FirstClock, FirstVal}|Rest], Size}
+	end.
 
 -spec sublist(vector_orddict(),non_neg_integer(),non_neg_integer()) -> vector_orddict().
 sublist({List,_Size}, Start, Len) ->

--- a/src/vector_orddict.erl
+++ b/src/vector_orddict.erl
@@ -31,7 +31,7 @@
 
 -export([new/0,
 	 get_smaller/2,
-     is_causally_compatible/4,
+	 get_smaller_from_id/3,
 	 insert/3,
 	 insert_bigger/3,
 	 sublist/3,
@@ -50,18 +50,6 @@
 new() ->
     {[],0}.
 
-is_causally_compatible(CommitClock, CommitTimeLowbound, DepClock, DepUpbound) ->
-    case ((CommitTimeLowbound == undefined) or (DepUpbound == undefined) or
-            (CommitTimeLowbound == []) or (DepUpbound == [])) of
-        true ->
-            true;
-        false ->
-%%            lager:info("CommitClock= ~p~n CommitTimeLowbound= ~p~n, DepClock = ~p~n, DepUpbound = ~p~n",
-%%                [CommitClock,CommitTimeLowbound, DepClock, DepUpbound]),
-            vectorclock:ge(CommitClock, CommitTimeLowbound) and vectorclock:le(DepClock, DepUpbound)
-    end.
-
-
 -spec get_smaller(vectorclock(),vector_orddict()) -> {undefined | {vectorclock(),term()},boolean()}.
 get_smaller(Vector,{List,_Size}) ->
     get_smaller_internal(Vector,List,true).
@@ -72,7 +60,7 @@ get_smaller_internal(_Vector,[],IsFirst) ->
 get_smaller_internal(Vector,[{FirstClock,FirstVal}|Rest],IsFirst) ->
     case vectorclock:le(FirstClock,Vector) of
 	true ->
-	    {{FirstVal, FirstClock},IsFirst};
+	    {{FirstClock,FirstVal},IsFirst};
 	false ->
 	    get_smaller_internal(Vector,Rest,false)
     end.
@@ -202,15 +190,15 @@ vector_orddict_insert_bigger_test() ->
     Vdict0 = vector_orddict:new(),
     %% Insert to empty dict
     CT1 = vectorclock:from_list([{dc1,4},{dc2,4}]),
-    Vdict1 = vector_orddict:insert_bigger(CT1, 1,Vdict0, clocksi),
+    Vdict1 = vector_orddict:insert_bigger(CT1, 1,Vdict0),
     ?assertEqual(1,vector_orddict:size(Vdict1)),
     %% Should not insert because smaller
     CT2 = vectorclock:from_list([{dc1,3},{dc2,3}]),
-    Vdict2 = vector_orddict:insert_bigger(CT2, 2, Vdict1, clocksi),
+    Vdict2 = vector_orddict:insert_bigger(CT2, 2, Vdict1),
     ?assertEqual(1,vector_orddict:size(Vdict2)),
     %% Should insert because bigger
     CT3 = vectorclock:from_list([{dc1,6},{dc2,10}]),
-    Vdict3 = vector_orddict:insert_bigger(CT3, 3, Vdict2, clocksi),
+    Vdict3 = vector_orddict:insert_bigger(CT3, 3, Vdict2),
     ?assertEqual(2,vector_orddict:size(Vdict3)).
 
 

--- a/src/vector_orddict.erl
+++ b/src/vector_orddict.erl
@@ -62,7 +62,7 @@ get_smaller_internal(_Vector,[],IsFirst) ->
     {undefined,IsFirst};
 get_smaller_internal(Vector,[{FirstItem,FirstVal}|Rest],IsFirst) ->
 	FirstClock = case FirstItem of
-		{CommitVC, _DepVC, _ReadTime} -> CommitVC;
+		{_CommitVC, DepVC, _ReadTime} -> DepVC;
 		CommitVC -> CommitVC
 	end,
     case vectorclock:le(FirstClock,Vector) of

--- a/src/vector_orddict.erl
+++ b/src/vector_orddict.erl
@@ -114,16 +114,22 @@ insert_bigger(Vector,Val,{List,Size}) ->
 
 -spec insert_bigger_internal(vectorclock(),term(),[{vectorclock(),term()}],non_neg_integer()) -> nonempty_vector_orddict().
 insert_bigger_internal(Vector,Val,[],0) ->
-    {[{Vector,Val}],1};
+	{[{Vector,Val}],1};
 
 insert_bigger_internal(Vector,Val,[{FirstClock,FirstVal}|Rest],Size) ->
-	FirstClock=case FirstVal of
-		{CommitVC, _DepVC, _ReadTime}->
+	ClockToCompare=case FirstVal of
+		{CommitVC, _DepVC, _ReadTime}-> %% physics
 			CommitVC;
 		CommitVC->
 			CommitVC
 	end,
-	case not vectorclock:le(Vector, FirstClock) of
+	ClockToCompare2=case Vector of
+		{CVC, _DVC, _RT}-> %% physics
+			CVC;
+		CVC->
+			CVC
+	end,
+	case not vectorclock:le(ClockToCompare2, ClockToCompare) of
 		true->
 			{[{Vector, Val}|[{FirstClock, FirstVal}|Rest]], Size+1};
 		false->

--- a/src/vectorclock.erl
+++ b/src/vectorclock.erl
@@ -177,6 +177,7 @@ merge(F, V1, V2) ->
 -spec for_all_keys(fun((non_neg_integer(), non_neg_integer()) -> boolean()), vectorclock(), vectorclock()) -> boolean().
 for_all_keys(F, V1, V2) ->
     %% We could but do not care about duplicate DC keys - finding duplicates is not worth the effort
+    lager:debug("~n V1: ~p~nV2 ~p", [V1, V2]),
     AllDCs = dict:fetch_keys(V1) ++ dict:fetch_keys(V2),
     Func = fun(DC) ->
         A = get_clock_of_dc(DC, V1),

--- a/src/vectorclock.erl
+++ b/src/vectorclock.erl
@@ -123,24 +123,40 @@ max_vc(undefined, V)-> V;
 max_vc([], V)-> V;
 max_vc(V, [])-> V;
 max_vc(V1, V2) ->
-    case ge(V1, V2) of
-        true ->
-            V1;
-        false ->
-            V2
+    NewVC = new(),
+    case V1 of
+        NewVC -> V2;
+        _->
+            case V2 of
+                NewVC ->V1;
+                _-> case ge(V1, V2) of
+                    true ->
+                        V1;
+                    false ->
+                        V2
+                end
+            end
     end.
+
 
 -spec min_vc(vectorclock(), vectorclock()) -> vectorclock().
 min_vc(V, ignore)-> V;
 min_vc(ignore, V)-> V;
-%%min_vc([], V)-> V;
-%%min_vc(V, [])-> V;
 min_vc(V1, V2) ->
-    case ge(V1, V2) of
-        true ->
-            V2;
-        false ->
-            V1
+    NewVC = new(),
+    
+    case V1 of
+        NewVC -> V2;
+        _->
+            case V2 of
+                NewVC ->V1;
+                _-> case ge(V1, V2) of
+                    true ->
+                        V2;
+                    false ->
+                        V1
+                end
+            end
     end.
 
 -spec min([vectorclock()]) -> vectorclock().

--- a/src/vectorclock.erl
+++ b/src/vectorclock.erl
@@ -47,8 +47,7 @@
     fetch/2,
     erase/2,
     map/2,
-    max_vc/2,
-    min_vc/2, to_json/1, from_json/1]).
+    to_json/1, from_json/1]).
 
 -export_type([vectorclock/0]).
 

--- a/src/vectorclock.erl
+++ b/src/vectorclock.erl
@@ -115,6 +115,8 @@ max_vc(V, ignore)-> V;
 max_vc(V, undefined)-> V;
 max_vc(ignore, V)-> V;
 max_vc(undefined, V)-> V;
+max_vc([], V)-> V;
+max_vc(V, [])-> V;
 max_vc(V1, V2) ->
     case ge(V1, V2) of
         true ->
@@ -126,6 +128,8 @@ max_vc(V1, V2) ->
 -spec min_vc(vectorclock(), vectorclock()) -> vectorclock().
 min_vc(V, ignore)-> V;
 min_vc(ignore, V)-> V;
+min_vc([], V)-> V;
+min_vc(V, [])-> V;
 min_vc(V1, V2) ->
     case ge(V1, V2) of
         true ->

--- a/src/vectorclock.erl
+++ b/src/vectorclock.erl
@@ -30,6 +30,8 @@
     set_clock_of_dc/3,
     create_commit_vector_clock/3,
     from_list/1,
+    from_dict/1,
+    to_dict/1,
     new/0,
     eq/2,
     lt/2,
@@ -54,6 +56,12 @@
 -spec new() -> vectorclock().
 new() ->
     orddict:new().
+
+to_dict(VC) ->
+    lists:to_dict(VC).
+
+from_dict(Dict) ->
+    lists:from_dict(Dict).
 
 fold(F, Acc, [{Key,Val}|D]) ->
     orddict:fold(F, F(Key, Val, Acc), D);

--- a/src/vectorclock.erl
+++ b/src/vectorclock.erl
@@ -28,7 +28,6 @@
 -export([
     get_clock_of_dc/2,
     set_clock_of_dc/3,
-%%    create_commit_vector_clock/3,
     from_list/1,
     from_dict/1,
     to_dict/1,
@@ -44,13 +43,11 @@
     strict_le/2,
     max/1,
     min/1,
-    fold/3,
     store/3,
     fetch/2,
     erase/2,
     map/2,
     max_vc/2,
-    %%    merge/3,
     min_vc/2, to_json/1, from_json/1]).
 
 -export_type([vectorclock/0]).
@@ -67,10 +64,6 @@ from_dict(Dict) -> Dict.
 
 size(VC) ->
     dict:size(VC).
-
-fold(F, Acc, [{Key,Val}|D]) ->
-    dict:fold(F, F(Key, Val, Acc), D);
-fold(F, Acc, []) when is_function(F, 3) -> Acc.
 
 find(Key, Orddict) ->
     dict:find(Key, Orddict).
@@ -96,14 +89,7 @@ get_clock_of_dc(Key, VectorClock) ->
 
 -spec set_clock_of_dc(any(), non_neg_integer(), vectorclock()) -> vectorclock().
 set_clock_of_dc(Key, Value, VectorClock) ->
-    case is_atom(VectorClock) of
-        true -> dict:store(Key, Value, new());
-        false -> dict:store(Key, Value, VectorClock)
-    end.
-
-%%-spec create_commit_vector_clock(any(), non_neg_integer(), vectorclock()) -> vectorclock().
-%%create_commit_vector_clock(Key, Value, VectorClock)->
-%%    set_clock_of_dc(Key, Value, VectorClock).
+        dict:store(Key, Value, VectorClock).
 
 -spec from_list([{any(), non_neg_integer()}]) -> vectorclock().
 from_list(List) ->
@@ -116,12 +102,12 @@ max([V1,V2|T]) -> max([merge(fun erlang:max/2, V1, V2)|T]).
 
 -spec max_vc(vectorclock(), vectorclock()) -> vectorclock().
 max_vc(V, V)-> V;
-max_vc(V, ignore)-> V;
-max_vc(V, undefined)-> V;
-max_vc(ignore, V)-> V;
-max_vc(undefined, V)-> V;
-max_vc([], V)-> V;
-max_vc(V, [])-> V;
+%%max_vc(V, ignore)-> V;
+%%max_vc(V, undefined)-> V;
+%%max_vc(ignore, V)-> V;
+%%max_vc(undefined, V)-> V;
+%%max_vc([], V)-> V;
+%%max_vc(V, [])-> V;
 max_vc(V1, V2) ->
     NewVC = new(),
     case V1 of

--- a/src/vectorclock.erl
+++ b/src/vectorclock.erl
@@ -57,39 +57,39 @@
 
 -spec new() -> vectorclock().
 new() ->
-    dict:new().
+    orddict:new().
 
-to_dict(VC) -> VC.
-%%    dict:from_list(VC).
+to_dict(VC) -> %VC.
+    orddict:from_list(VC).
 
-from_dict(Dict) -> Dict.
-%%    from_list(dict:to_list(Dict)).
+from_dict(Dict) -> %Dict.
+    from_list(orddict:to_list(Dict)).
 
 size(VC) ->
-    dict:size(VC).
+    orddict:size(VC).
 
 fold(F, Acc, [{Key,Val}|D]) ->
-    dict:fold(F, F(Key, Val, Acc), D);
+    orddict:fold(F, F(Key, Val, Acc), D);
 fold(F, Acc, []) when is_function(F, 3) -> Acc.
 
 find(Key, Orddict) ->
-    dict:find(Key, Orddict).
+    orddict:find(Key, Orddict).
 
 store(Key, Value, Orddict1) ->
-    dict:store(Key, Value, Orddict1).
+    orddict:store(Key, Value, Orddict1).
 
 fetch(Key, Orddict)->
-    dict:fetch(Key, Orddict).
+    orddict:fetch(Key, Orddict).
 
 erase(Key, Orddict1)->
-    dict:erase(Key, Orddict1).
+    orddict:erase(Key, Orddict1).
 
 map(Fun, Orddict1) ->
-    dict:map(Fun, Orddict1).
+    orddict:map(Fun, Orddict1).
 
 -spec get_clock_of_dc(any(), vectorclock()) -> non_neg_integer().
 get_clock_of_dc(Key, VectorClock) ->
-    case dict:find(Key, VectorClock) of
+    case orddict:find(Key, VectorClock) of
         {ok, Value} -> Value;
         error -> 0
     end.
@@ -97,8 +97,8 @@ get_clock_of_dc(Key, VectorClock) ->
 -spec set_clock_of_dc(any(), non_neg_integer(), vectorclock()) -> vectorclock().
 set_clock_of_dc(Key, Value, VectorClock) ->
     case is_atom(VectorClock) of
-        true -> dict:store(Key, Value, new());
-        false -> dict:store(Key, Value, VectorClock)
+        true -> orddict:store(Key, Value, new());
+        false -> orddict:store(Key, Value, VectorClock)
     end.
 
 -spec create_commit_vector_clock(any(), non_neg_integer(), vectorclock()) -> vectorclock().
@@ -107,7 +107,7 @@ create_commit_vector_clock(Key, Value, VectorClock)->
 
 -spec from_list([{any(), non_neg_integer()}]) -> vectorclock().
 from_list(List) ->
-    dict:from_list(List).
+    orddict:from_list(List).
 
 -spec max([vectorclock()]) -> vectorclock().
 max([]) -> new();
@@ -150,7 +150,7 @@ min([V1,V2|T]) -> min([merge(fun erlang:min/2, V1, V2)|T]).
 
 -spec merge(fun((non_neg_integer(), non_neg_integer()) -> non_neg_integer()), vectorclock(), vectorclock()) -> vectorclock().
 merge(F, V1, V2) ->
-    AllDCs = dict:fetch_keys(V1) ++ dict:fetch_keys(V2),
+    AllDCs = orddict:fetch_keys(V1) ++ orddict:fetch_keys(V2),
     Func = fun(DC) ->
         A = get_clock_of_dc(DC, V1),
         B = get_clock_of_dc(DC, V2),
@@ -161,7 +161,7 @@ merge(F, V1, V2) ->
 -spec for_all_keys(fun((non_neg_integer(), non_neg_integer()) -> boolean()), vectorclock(), vectorclock()) -> boolean().
 for_all_keys(F, V1, V2) ->
     %% We could but do not care about duplicate DC keys - finding duplicates is not worth the effort
-    AllDCs = dict:fetch_keys(V1) ++ dict:fetch_keys(V2),
+    AllDCs = orddict:fetch_keys(V1) ++ orddict:fetch_keys(V2),
     Func = fun(DC) ->
         A = get_clock_of_dc(DC, V1),
         B = get_clock_of_dc(DC, V2),
@@ -192,7 +192,7 @@ strict_le(V1,V2) -> le(V1,V2) and (not eq(V1,V2)).
 
 to_json(VectorClock) ->
     Elements =
-        dict:fold(fun(DCID,Time,Acc) ->
+        orddict:fold(fun(DCID,Time,Acc) ->
             Acc++[[{dcid_and_time,
                 [json_utilities:dcid_to_json(DCID),Time]}]]
         end,[],VectorClock),

--- a/src/vectorclock.erl
+++ b/src/vectorclock.erl
@@ -29,6 +29,7 @@
     get_clock_of_dc/2,
     set_clock_of_dc/3,
     from_list/1,
+    to_list/1,
     from_dict/1,
     to_dict/1,
     size/1,
@@ -93,6 +94,10 @@ set_clock_of_dc(Key, Value, VectorClock) ->
 -spec from_list([{any(), non_neg_integer()}]) -> vectorclock().
 from_list(List) ->
     dict:from_list(List).
+
+-spec to_list(vectorclock()) -> [{any(), non_neg_integer()}].
+to_list(Dict) ->
+    dict:to_list(Dict).
 
 -spec max([vectorclock()]) -> vectorclock().
 max([]) -> new();

--- a/src/vectorclock.erl
+++ b/src/vectorclock.erl
@@ -50,7 +50,7 @@
     erase/2,
     map/2,
     max_vc/2,
-    merge/3,
+%%    merge/3,
     min_vc/2, to_json/1, from_json/1]).
 
 -export_type([vectorclock/0]).
@@ -150,16 +150,13 @@ min([V1,V2|T]) -> min([merge(fun erlang:min/2, V1, V2)|T]).
 
 -spec merge(fun((non_neg_integer(), non_neg_integer()) -> non_neg_integer()), vectorclock(), vectorclock()) -> vectorclock().
 merge(F, V1, V2) ->
-    orddict:merge(F, V1, V2).
-    
-%%
-%%    AllDCs = orddict:fetch_keys(V1) ++ orddict:fetch_keys(V2),
-%%    Func = fun(DC) ->
-%%        A = get_clock_of_dc(DC, V1),
-%%        B = get_clock_of_dc(DC, V2),
-%%        {DC, F(A, B)}
-%%           end,
-%%    from_list(lists:map(Func, AllDCs)).
+    AllDCs = orddict:fetch_keys(V1) ++ orddict:fetch_keys(V2),
+    Func = fun(DC) ->
+        A = get_clock_of_dc(DC, V1),
+        B = get_clock_of_dc(DC, V2),
+        {DC, F(A, B)}
+           end,
+    from_list(lists:map(Func, AllDCs)).
 
 -spec for_all_keys(fun((non_neg_integer(), non_neg_integer()) -> boolean()), vectorclock(), vectorclock()) -> boolean().
 for_all_keys(F, V1, V2) ->

--- a/src/vectorclock.erl
+++ b/src/vectorclock.erl
@@ -58,10 +58,10 @@ new() ->
     orddict:new().
 
 to_dict(VC) ->
-    lists:to_dict(VC).
+    dict:from_list(VC).
 
 from_dict(Dict) ->
-    lists:from_dict(Dict).
+    from_list(dict:to_list(Dict)).
 
 fold(F, Acc, [{Key,Val}|D]) ->
     orddict:fold(F, F(Key, Val, Acc), D);

--- a/src/vectorclock.erl
+++ b/src/vectorclock.erl
@@ -50,6 +50,7 @@
     erase/2,
     map/2,
     max_vc/2,
+    merge/3,
     min_vc/2, to_json/1, from_json/1]).
 
 -export_type([vectorclock/0]).

--- a/src/vectorclock.erl
+++ b/src/vectorclock.erl
@@ -150,13 +150,16 @@ min([V1,V2|T]) -> min([merge(fun erlang:min/2, V1, V2)|T]).
 
 -spec merge(fun((non_neg_integer(), non_neg_integer()) -> non_neg_integer()), vectorclock(), vectorclock()) -> vectorclock().
 merge(F, V1, V2) ->
-    AllDCs = orddict:fetch_keys(V1) ++ orddict:fetch_keys(V2),
-    Func = fun(DC) ->
-        A = get_clock_of_dc(DC, V1),
-        B = get_clock_of_dc(DC, V2),
-        {DC, F(A, B)}
-           end,
-    from_list(lists:map(Func, AllDCs)).
+    orddict:merge(F, V1, V2).
+    
+%%
+%%    AllDCs = orddict:fetch_keys(V1) ++ orddict:fetch_keys(V2),
+%%    Func = fun(DC) ->
+%%        A = get_clock_of_dc(DC, V1),
+%%        B = get_clock_of_dc(DC, V2),
+%%        {DC, F(A, B)}
+%%           end,
+%%    from_list(lists:map(Func, AllDCs)).
 
 -spec for_all_keys(fun((non_neg_integer(), non_neg_integer()) -> boolean()), vectorclock(), vectorclock()) -> boolean().
 for_all_keys(F, V1, V2) ->

--- a/src/vectorclock.erl
+++ b/src/vectorclock.erl
@@ -100,48 +100,6 @@ max([]) -> new();
 max([V]) -> V;
 max([V1,V2|T]) -> max([merge(fun erlang:max/2, V1, V2)|T]).
 
--spec max_vc(vectorclock(), vectorclock()) -> vectorclock().
-max_vc(V, V)-> V;
-%%max_vc(V, ignore)-> V;
-%%max_vc(V, undefined)-> V;
-%%max_vc(ignore, V)-> V;
-%%max_vc(undefined, V)-> V;
-%%max_vc([], V)-> V;
-%%max_vc(V, [])-> V;
-max_vc(V1, V2) ->
-    NewVC = new(),
-    case V1 of
-        NewVC -> V2;
-        _->
-            case V2 of
-                NewVC ->V1;
-                _-> case ge(V1, V2) of
-                    true ->
-                        V1;
-                    false ->
-                        V2
-                end
-            end
-    end.
-
-
--spec min_vc(vectorclock(), vectorclock()) -> vectorclock().
-min_vc(V1, V2) ->
-    NewVC = new(),
-    
-    case V1 of
-        NewVC -> V2;
-        _->
-            case V2 of
-                NewVC ->V1;
-                _-> case ge(V1, V2) of
-                    true ->
-                        V2;
-                    false ->
-                        V1
-                end
-            end
-    end.
 
 -spec min([vectorclock()]) -> vectorclock().
 min([]) -> new();

--- a/src/vectorclock.erl
+++ b/src/vectorclock.erl
@@ -32,6 +32,7 @@
     from_list/1,
     from_dict/1,
     to_dict/1,
+    size/1,
     new/0,
     eq/2,
     lt/2,
@@ -62,6 +63,9 @@ to_dict(VC) ->
 
 from_dict(Dict) ->
     from_list(dict:to_list(Dict)).
+
+size(VC) ->
+    orddict:size(VC).
 
 fold(F, Acc, [{Key,Val}|D]) ->
     orddict:fold(F, F(Key, Val, Acc), D);

--- a/src/vectorclock.erl
+++ b/src/vectorclock.erl
@@ -126,8 +126,6 @@ max_vc(V1, V2) ->
 
 
 -spec min_vc(vectorclock(), vectorclock()) -> vectorclock().
-min_vc(V, ignore)-> V;
-min_vc(ignore, V)-> V;
 min_vc(V1, V2) ->
     NewVC = new(),
     

--- a/src/vectorclock.erl
+++ b/src/vectorclock.erl
@@ -63,7 +63,7 @@ to_dict(VC) -> %VC.
     orddict:from_list(VC).
 
 from_dict(Dict) -> %Dict.
-    from_list(orddict:to_list(Dict)).
+    from_list(dict:to_list(Dict)).
 
 size(VC) ->
     orddict:size(VC).

--- a/src/vectorclock.erl
+++ b/src/vectorclock.erl
@@ -28,7 +28,7 @@
 -export([
     get_clock_of_dc/2,
     set_clock_of_dc/3,
-    create_commit_vector_clock/3,
+%%    create_commit_vector_clock/3,
     from_list/1,
     from_dict/1,
     to_dict/1,
@@ -57,39 +57,39 @@
 
 -spec new() -> vectorclock().
 new() ->
-    orddict:new().
+    dict:new().
 
-to_dict(VC) -> %VC.
-    orddict:from_list(VC).
+to_dict(VC) -> VC.
+%%    dict:from_list(VC).
 
-from_dict(Dict) -> %Dict.
-    from_list(dict:to_list(Dict)).
+from_dict(Dict) -> Dict.
+%%    from_list(dict:to_list(Dict)).
 
 size(VC) ->
-    orddict:size(VC).
+    dict:size(VC).
 
 fold(F, Acc, [{Key,Val}|D]) ->
-    orddict:fold(F, F(Key, Val, Acc), D);
+    dict:fold(F, F(Key, Val, Acc), D);
 fold(F, Acc, []) when is_function(F, 3) -> Acc.
 
 find(Key, Orddict) ->
-    orddict:find(Key, Orddict).
+    dict:find(Key, Orddict).
 
 store(Key, Value, Orddict1) ->
-    orddict:store(Key, Value, Orddict1).
+    dict:store(Key, Value, Orddict1).
 
 fetch(Key, Orddict)->
-    orddict:fetch(Key, Orddict).
+    dict:fetch(Key, Orddict).
 
 erase(Key, Orddict1)->
-    orddict:erase(Key, Orddict1).
+    dict:erase(Key, Orddict1).
 
 map(Fun, Orddict1) ->
-    orddict:map(Fun, Orddict1).
+    dict:map(Fun, Orddict1).
 
 -spec get_clock_of_dc(any(), vectorclock()) -> non_neg_integer().
 get_clock_of_dc(Key, VectorClock) ->
-    case orddict:find(Key, VectorClock) of
+    case dict:find(Key, VectorClock) of
         {ok, Value} -> Value;
         error -> 0
     end.
@@ -97,17 +97,17 @@ get_clock_of_dc(Key, VectorClock) ->
 -spec set_clock_of_dc(any(), non_neg_integer(), vectorclock()) -> vectorclock().
 set_clock_of_dc(Key, Value, VectorClock) ->
     case is_atom(VectorClock) of
-        true -> orddict:store(Key, Value, new());
-        false -> orddict:store(Key, Value, VectorClock)
+        true -> dict:store(Key, Value, new());
+        false -> dict:store(Key, Value, VectorClock)
     end.
 
--spec create_commit_vector_clock(any(), non_neg_integer(), vectorclock()) -> vectorclock().
-create_commit_vector_clock(Key, Value, VectorClock)->
-    set_clock_of_dc(Key, Value, VectorClock).
+%%-spec create_commit_vector_clock(any(), non_neg_integer(), vectorclock()) -> vectorclock().
+%%create_commit_vector_clock(Key, Value, VectorClock)->
+%%    set_clock_of_dc(Key, Value, VectorClock).
 
 -spec from_list([{any(), non_neg_integer()}]) -> vectorclock().
 from_list(List) ->
-    orddict:from_list(List).
+    dict:from_list(List).
 
 -spec max([vectorclock()]) -> vectorclock().
 max([]) -> new();
@@ -150,7 +150,7 @@ min([V1,V2|T]) -> min([merge(fun erlang:min/2, V1, V2)|T]).
 
 -spec merge(fun((non_neg_integer(), non_neg_integer()) -> non_neg_integer()), vectorclock(), vectorclock()) -> vectorclock().
 merge(F, V1, V2) ->
-    AllDCs = orddict:fetch_keys(V1) ++ orddict:fetch_keys(V2),
+    AllDCs = dict:fetch_keys(V1) ++ dict:fetch_keys(V2),
     Func = fun(DC) ->
         A = get_clock_of_dc(DC, V1),
         B = get_clock_of_dc(DC, V2),
@@ -161,7 +161,7 @@ merge(F, V1, V2) ->
 -spec for_all_keys(fun((non_neg_integer(), non_neg_integer()) -> boolean()), vectorclock(), vectorclock()) -> boolean().
 for_all_keys(F, V1, V2) ->
     %% We could but do not care about duplicate DC keys - finding duplicates is not worth the effort
-    AllDCs = orddict:fetch_keys(V1) ++ orddict:fetch_keys(V2),
+    AllDCs = dict:fetch_keys(V1) ++ dict:fetch_keys(V2),
     Func = fun(DC) ->
         A = get_clock_of_dc(DC, V1),
         B = get_clock_of_dc(DC, V2),
@@ -192,7 +192,7 @@ strict_le(V1,V2) -> le(V1,V2) and (not eq(V1,V2)).
 
 to_json(VectorClock) ->
     Elements =
-        orddict:fold(fun(DCID,Time,Acc) ->
+        dict:fold(fun(DCID,Time,Acc) ->
             Acc++[[{dcid_and_time,
                 [json_utilities:dcid_to_json(DCID),Time]}]]
         end,[],VectorClock),

--- a/src/vectorclock.erl
+++ b/src/vectorclock.erl
@@ -177,7 +177,7 @@ merge(F, V1, V2) ->
 -spec for_all_keys(fun((non_neg_integer(), non_neg_integer()) -> boolean()), vectorclock(), vectorclock()) -> boolean().
 for_all_keys(F, V1, V2) ->
     %% We could but do not care about duplicate DC keys - finding duplicates is not worth the effort
-    lager:debug("~n V1: ~p~nV2 ~p", [V1, V2]),
+%%    lager:debug("~n V1: ~p~nV2 ~p", [V1, V2]),
     AllDCs = dict:fetch_keys(V1) ++ dict:fetch_keys(V2),
     Func = fun(DC) ->
         A = get_clock_of_dc(DC, V1),


### PR DESCRIPTION
In antidote, many calls to vectorclock were simply done by calling dict.
Now, those calls have been replaced by calls to the vectorclock module.
The changes in this pull request add the functions that were missing, and adapts some functions to be used by the PhysiCS protocol.
